### PR TITLE
Align kernel to each Spark version for cast string to timestamp

### DIFF
--- a/src/main/cpp/src/CastStringJni.cpp
+++ b/src/main/cpp/src/CastStringJni.cpp
@@ -278,22 +278,27 @@ Java_com_nvidia_spark_rapids_jni_CastStrings_parseTimestampStrings(JNIEnv* env,
                                                                    int default_timezone_index,
                                                                    bool is_default_timezone_dst,
                                                                    long default_epoch_day,
-                                                                   jlong timezone_info_column)
+                                                                   jlong timezone_info_column,
+                                                                   jlong transitions_table)
 {
   JNI_NULL_CHECK(env, input_column, "input column is null", 0);
   JNI_NULL_CHECK(env, timezone_info_column, "timezone info column is null", 0);
+  JNI_NULL_CHECK(env, transitions_table, "transitions table is null", 0);
+
   try {
     cudf::jni::auto_set_device(env);
 
     auto const input_view =
       cudf::strings_column_view(*reinterpret_cast<cudf::column_view const*>(input_column));
     auto const* tz_info_view = reinterpret_cast<cudf::column_view const*>(timezone_info_column);
+    auto const* transitions  = reinterpret_cast<cudf::table_view const*>(transitions_table);
     return cudf::jni::release_as_jlong(
       spark_rapids_jni::parse_timestamp_strings(input_view,
                                                 default_timezone_index,
                                                 is_default_timezone_dst,
                                                 default_epoch_day,
-                                                *tz_info_view));
+                                                *tz_info_view,
+                                                *transitions));
   }
   CATCH_STD(env, 0);
 }

--- a/src/main/cpp/src/CastStringJni.cpp
+++ b/src/main/cpp/src/CastStringJni.cpp
@@ -279,7 +279,8 @@ Java_com_nvidia_spark_rapids_jni_CastStrings_parseTimestampStrings(JNIEnv* env,
                                                                    bool is_default_timezone_dst,
                                                                    long default_epoch_day,
                                                                    jlong timezone_info_column,
-                                                                   jlong transitions_table)
+                                                                   jlong transitions_table,
+                                                                   jboolean is_spark_320)
 {
   JNI_NULL_CHECK(env, input_column, "input column is null", 0);
   JNI_NULL_CHECK(env, timezone_info_column, "timezone info column is null", 0);
@@ -298,7 +299,8 @@ Java_com_nvidia_spark_rapids_jni_CastStrings_parseTimestampStrings(JNIEnv* env,
                                                 is_default_timezone_dst,
                                                 default_epoch_day,
                                                 *tz_info_view,
-                                                *transitions));
+                                                *transitions,
+                                                is_spark_320));
   }
   CATCH_STD(env, 0);
 }

--- a/src/main/cpp/src/cast_string.hpp
+++ b/src/main/cpp/src/cast_string.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/table/table.hpp>
 #include <cudf/types.hpp>
 
 #include <rmm/resource_ref.hpp>
@@ -162,10 +163,11 @@ std::unique_ptr<cudf::column> long_to_binary_string(
  */
 std::unique_ptr<cudf::column> parse_timestamp_strings(
   cudf::strings_column_view const& input,
-  cudf::size_type const default_tz_index,
-  bool const is_default_tz_dst,
-  int64_t const default_epoch_day,
+  cudf::size_type default_tz_index,
+  bool is_default_tz_dst,
+  int64_t default_epoch_day,
   cudf::column_view const& tz_info,
+  cudf::table_view const& transitions,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 

--- a/src/main/cpp/src/cast_string.hpp
+++ b/src/main/cpp/src/cast_string.hpp
@@ -168,6 +168,7 @@ std::unique_ptr<cudf::column> parse_timestamp_strings(
   int64_t default_epoch_day,
   cudf::column_view const& tz_info,
   cudf::table_view const& transitions,
+  bool is_spark_320,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 

--- a/src/main/cpp/src/datetime_utils.cuh
+++ b/src/main/cpp/src/datetime_utils.cuh
@@ -135,7 +135,7 @@ struct date_time_utils {
   __device__ static bool is_valid_time(int hour, int minute, int second, int microseconds)
   {
     return (hour >= 0 && hour < 24) && (minute >= 0 && minute < 60) &&
-           (second >= 0 && second < 60) && (microseconds >= 0 && microseconds < 1000000);
+           (second >= 0 && second < 60) && (microseconds >= 0 && microseconds < 1'000'000);
   }
 };
 

--- a/src/main/cpp/src/datetime_utils.cuh
+++ b/src/main/cpp/src/datetime_utils.cuh
@@ -175,62 +175,6 @@ struct date_segments {
   int32_t day;
 };
 
-/**
- * @brief Represents local date time in a timezone with microsecond accuracy.
- * Spark stores timestamp into Long in microseconds.
- * A Long is able to represent a timestamp with max 6 digits of microseconds.
- * The formula is: Long.MaxValue/microseconds_per_year + 1970.
- */
-struct ts_segments {
-  /**
-   * @brief Constructor a default timestamp segments.
-   * By default, use epoch date with mid-night time: "1970-01-01 00:00:00.000000".
-   */
-  __device__ ts_segments()
-    : year(1970), month(1), day(1), hour(0), minute(0), second(0), microseconds(0)
-  {
-  }
-
-  /**
-   * @brief Is this timestamp segments valid.
-   */
-  __device__ bool is_valid_ts() const
-  {
-    return date_time_utils::is_valid_date_for_timestamp(year, month, day) &&
-           date_time_utils::is_valid_time(hour, minute, second, microseconds);
-  }
-
-  /**
-   * @brief Get days since epoch 1970-01-01.
-   * Can handle all int years.
-   */
-  __device__ int64_t to_epoch_day() const
-  {
-    return date_time_utils::to_epoch_day(year, month, day);
-  }
-
-  // max 6 digits for Spark timestamp
-  int32_t year;
-
-  // 1-12
-  int32_t month;
-
-  // 1-31; it is 29 for leap February, or 28 for regular February
-  int32_t day;
-
-  // 0-23
-  int32_t hour;
-
-  // 0-59
-  int32_t minute;
-
-  // 0-59
-  int32_t second;
-
-  // 0-999999, only parse 6 digits, ignore/truncate the rest digits
-  int32_t microseconds;
-};
-
 struct overflow_checker {
   /**
    * Calculate the timestamp from epoch seconds and microseconds with checking overflow

--- a/src/main/cpp/src/datetime_utils.cuh
+++ b/src/main/cpp/src/datetime_utils.cuh
@@ -59,10 +59,10 @@ struct date_time_utils {
   __device__ static int64_t to_epoch_day(int year, int month, int day)
   {
     int32_t y          = year - (month <= 2);
-    const int32_t era  = (y >= 0 ? y : y - 399) / 400;
-    const uint32_t yoe = static_cast<uint32_t>(y - era * 400);                           // [0, 399]
-    const uint32_t doy = (153 * (month > 2 ? month - 3 : month + 9) + 2) / 5 + day - 1;  // [0, 365]
-    const uint32_t doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;  // [0, 146096]
+    int32_t const era  = (y >= 0 ? y : y - 399) / 400;
+    uint32_t const yoe = static_cast<uint32_t>(y - era * 400);                           // [0, 399]
+    uint32_t const doy = (153 * (month > 2 ? month - 3 : month + 9) + 2) / 5 + day - 1;  // [0, 365]
+    uint32_t const doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;  // [0, 146096]
     return era * 146097L + doe - 719468L;
   }
 
@@ -79,12 +79,12 @@ struct date_time_utils {
   {
     int64_t z = static_cast<int64_t>(epoch_day);
     z += 719468;
-    const int32_t era  = static_cast<int32_t>((z >= 0 ? z : z - 146096) / 146097);
-    const uint32_t doe = static_cast<uint32_t>(z - era * 146097);                // [0, 146096]
-    const uint32_t yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;  // [0, 399]
-    const int32_t y    = static_cast<uint32_t>(yoe) + era * 400;
-    const uint32_t doy = doe - (365 * yoe + yoe / 4 - yoe / 100);                // [0, 365]
-    const uint32_t mp  = (5 * doy + 2) / 153;                                    // [0, 11]
+    int32_t const era  = static_cast<int32_t>((z >= 0 ? z : z - 146096) / 146097);
+    uint32_t const doe = static_cast<uint32_t>(z - era * 146097);                // [0, 146096]
+    uint32_t const yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;  // [0, 399]
+    int32_t const y    = static_cast<uint32_t>(yoe) + era * 400;
+    uint32_t const doy = doe - (365 * yoe + yoe / 4 - yoe / 100);                // [0, 365]
+    uint32_t const mp  = (5 * doy + 2) / 153;                                    // [0, 11]
     day                = doy - (153 * mp + 2) / 5 + 1;                           // [1, 31]
     month              = mp < 10 ? mp + 3 : mp - 9;                              // [1, 12]
     year               = y + (month <= 2);

--- a/src/main/cpp/src/timezones.cu
+++ b/src/main/cpp/src/timezones.cu
@@ -70,26 +70,7 @@ struct convert_timestamp_tz_functor {
    */
   __device__ timestamp_type operator()(timestamp_type const& timestamp) const
   {
-    auto const utc_instants = transitions.child().child(0);
-    auto const tz_instants  = transitions.child().child(1);
-    auto const utc_offsets  = transitions.child().child(2);
-
-    auto const epoch_seconds = static_cast<int64_t>(
-      cuda::std::chrono::duration_cast<cudf::duration_s>(timestamp.time_since_epoch()).count());
-    auto const tz_transitions = cudf::list_device_view{transitions, tz_index};
-    auto const list_size      = tz_transitions.size();
-
-    auto const transition_times = cudf::device_span<int64_t const>(
-      (to_utc ? tz_instants : utc_instants).data<int64_t>() + tz_transitions.element_offset(0),
-      static_cast<size_t>(list_size));
-
-    auto const it = thrust::upper_bound(
-      thrust::seq, transition_times.begin(), transition_times.end(), epoch_seconds);
-    auto const idx         = static_cast<size_type>(thrust::distance(transition_times.begin(), it));
-    auto const list_offset = tz_transitions.element_offset(idx - 1);
-    auto const utc_offset  = cuda::std::chrono::duration_cast<duration_type>(
-      cudf::duration_s{static_cast<int64_t>(utc_offsets.element<int32_t>(list_offset))});
-    return to_utc ? timestamp - utc_offset : timestamp + utc_offset;
+    return spark_rapids_jni::convert_timestamp(timestamp, transitions, tz_index, to_utc);
   }
 };
 

--- a/src/main/cpp/src/timezones.hpp
+++ b/src/main/cpp/src/timezones.hpp
@@ -68,6 +68,28 @@ std::unique_ptr<cudf::column> convert_utc_timestamp_to_timezone(
   rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
 
 /**
+ * @brief Convert input column timestamps in UTC to specified timezone
+ *
+ * The transition rules are in enclosed in a table, and the index corresponding to the
+ * specific timezone is given.
+ *
+ * This method is the inverse of convert_timestamp_to_utc.
+ *
+ * @param input the column of input timestamps in UTC
+ * @param transitions the table of transitions for all timezones
+ * @param tz_indices the indices of the timezones,
+ * each index is the row in `transitions` corresponding to the specific timezone
+ * @param stream CUDA stream used for device memory operations and kernel launches.
+ * @param mr Device memory resource used to allocate the returned timestamp column's memory
+ */
+std::unique_ptr<cudf::column> convert_utc_timestamp_to_timezone(
+  cudf::column_view const& input,
+  cudf::table_view const& transitions,
+  cudf::column_view const& tz_indices,
+  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
+
+/**
  * @brief Convert input column timestamps in multiple timezones to UTC.
  *
  * Note: The input timestamps are splited into seconds and microseconds columns to handle special

--- a/src/main/java/com/nvidia/spark/rapids/jni/CastStrings.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/CastStrings.java
@@ -194,7 +194,7 @@ public class CastStrings {
 
     return new ColumnVector(parseTimestampStrings(
         input.getNativeView(), defaultTimeZoneIndex, isDefaultTimeZoneDST,
-        defaultEpochDay, timeZoneInfo.getNativeView(), transitions.getNativeView()));
+        defaultEpochDay, timeZoneInfo.getNativeView(), transitions.getNativeView(), isSpark320));
   }
 
   private static ColumnVector convertToTimestamp(
@@ -271,7 +271,8 @@ public class CastStrings {
   public static ColumnVector toTimestamp(
       ColumnView input,
       String defaultTimeZone,
-      boolean ansi_enabled) {
+      boolean ansi_enabled,
+      boolean isSpark320) {
 
     // 1. check default timezone is valid
     Integer defaultTimeZoneIndex = GpuTimeZoneDB.getIndexToTransitionTable(defaultTimeZone);
@@ -287,7 +288,8 @@ public class CastStrings {
     try (ColumnVector tzInfo = GpuTimeZoneDB.getTimeZoneInfo();
          Table transitions = GpuTimeZoneDB.getTransitions();
         ColumnVector parseResult = parseTimestampStrings(
-            input, defaultTimeZoneIndex, isDefaultTimeZoneDST, defaultEpochDay, tzInfo, transitions);
+            input, defaultTimeZoneIndex, isDefaultTimeZoneDST, defaultEpochDay, tzInfo, 
+            transitions, isSpark320);
         ColumnView invalid = parseResult.getChildColumnView(0);
         ColumnView tsSeconds = parseResult.getChildColumnView(1);
         ColumnView tsMicroseconds = parseResult.getChildColumnView(2);

--- a/src/main/java/com/nvidia/spark/rapids/jni/CastStrings.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/CastStrings.java
@@ -186,11 +186,12 @@ public class CastStrings {
   static ColumnVector parseTimestampStrings(
       ColumnView input, int defaultTimeZoneIndex,
       boolean isDefaultTimeZoneDST, long defaultEpochDay,
-      ColumnView timeZoneInfo) {
+      ColumnView timeZoneInfo,
+      Table transitions) {
 
     return new ColumnVector(parseTimestampStrings(
         input.getNativeView(), defaultTimeZoneIndex, isDefaultTimeZoneDST,
-        defaultEpochDay, timeZoneInfo.getNativeView()));
+        defaultEpochDay, timeZoneInfo.getNativeView(), transitions.getNativeView()));
   }
 
   private static ColumnVector convertToTimestamp(
@@ -281,8 +282,9 @@ public class CastStrings {
 
     // 2. parse to intermediate result
     try (ColumnVector tzInfo = GpuTimeZoneDB.getTimeZoneInfo();
+         Table transitions = GpuTimeZoneDB.getTransitions();
         ColumnVector parseResult = parseTimestampStrings(
-            input, defaultTimeZoneIndex, isDefaultTimeZoneDST, defaultEpochDay, tzInfo);
+            input, defaultTimeZoneIndex, isDefaultTimeZoneDST, defaultEpochDay, tzInfo, transitions);
         ColumnView invalid = parseResult.getChildColumnView(0);
         ColumnView tsSeconds = parseResult.getChildColumnView(1);
         ColumnView tsMicroseconds = parseResult.getChildColumnView(2);
@@ -351,7 +353,7 @@ public class CastStrings {
 
   private static native long parseTimestampStrings(
       long input, int defaultTimezoneIndex, boolean isDefaultTimeZoneDST,
-      long defaultEpochDay, long timeZoneInfo);
+      long defaultEpochDay, long timeZoneInfo, long transitions);
 
   private static native long parseDateStringsToDate(long input);
 

--- a/src/main/java/com/nvidia/spark/rapids/jni/CastStrings.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/CastStrings.java
@@ -181,13 +181,16 @@ public class CastStrings {
    * @param timeZoneInfo Timezone info column:
    *   STRUCT<tz_name: string, index_to_transition_table: int, is_DST: int8>,
    *   Refer to `GpuTimeZoneDB` for more details.
+   * @param transitions Timezone transition table.
+   * @param isSpark320 is Spark 3.2.0 version
    * @return a struct column constains 7 columns described above.
    */
   static ColumnVector parseTimestampStrings(
       ColumnView input, int defaultTimeZoneIndex,
       boolean isDefaultTimeZoneDST, long defaultEpochDay,
       ColumnView timeZoneInfo,
-      Table transitions) {
+      Table transitions,
+      boolean isSpark320) {
 
     return new ColumnVector(parseTimestampStrings(
         input.getNativeView(), defaultTimeZoneIndex, isDefaultTimeZoneDST,
@@ -353,7 +356,7 @@ public class CastStrings {
 
   private static native long parseTimestampStrings(
       long input, int defaultTimezoneIndex, boolean isDefaultTimeZoneDST,
-      long defaultEpochDay, long timeZoneInfo, long transitions);
+      long defaultEpochDay, long timeZoneInfo, long transitions, boolean isSpark320);
 
   private static native long parseDateStringsToDate(long input);
 

--- a/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
@@ -524,7 +524,8 @@ public class CastStringsTest {
             /* is default tz DST */ false,
             defaultEpochDay,
             tzInfo,
-            transitions);
+            transitions,
+            /* is spark 320 */ false);
         ColumnVector expectedReturnType = ColumnVector
             .fromBoxedUnsignedBytes(expected_return_type.toArray(new Byte[0]));
         ColumnVector expectedUtcTs = ColumnVector.fromBoxedLongs(expected_utc_seconds.toArray(new Long[0]));
@@ -591,7 +592,8 @@ public class CastStringsTest {
       }
     }
     try (ColumnVector inputCv = ColumnVector.fromStrings(input.toArray(new String[0]));
-        ColumnVector actual = CastStrings.toTimestamp(inputCv, "Z", /* ansi */ false);
+        ColumnVector actual = CastStrings.toTimestamp(
+            inputCv, "Z", /* ansi */ false, /* is spark 320 */ false);
         ColumnVector expected = ColumnVector.timestampMicroSecondsFromBoxedLongs(
             expectedTS.toArray(new Long[0]))) {
       AssertUtils.assertColumnsAreEqual(expected, actual);
@@ -646,7 +648,8 @@ public class CastStringsTest {
       }
     }
     try (ColumnVector inputCv = ColumnVector.fromStrings(input.toArray(new String[0]));
-        ColumnVector actual = CastStrings.toTimestamp(inputCv, "Z", /* ansi */ false);
+        ColumnVector actual = CastStrings.toTimestamp(
+            inputCv, "Z", /* ansi */ false, /* is spark 320 */ false);
         ColumnVector expected = ColumnVector.timestampMicroSecondsFromBoxedLongs(
             expectedTS.toArray(new Long[0]))) {
       AssertUtils.assertColumnsAreEqual(expected, actual);
@@ -871,7 +874,8 @@ public class CastStringsTest {
             /* is default tz DST */ false,
             defaultEpochDay,
             tzInfo,
-            transitions);
+            transitions,
+            /* is spark 320 */ false);
         ColumnVector expectedReturnType = ColumnVector
             .fromBoxedUnsignedBytes(expected_return_type.toArray(new Byte[0]));
         ColumnVector expectedUtcTs = ColumnVector.fromBoxedLongs(expected_utc_seconds.toArray(new Long[0]));
@@ -935,14 +939,16 @@ public class CastStringsTest {
       }
     }
     try (ColumnVector inputCv = ColumnVector.fromStrings(input.toArray(new String[0]));
-        ColumnVector actual = CastStrings.toTimestamp(inputCv, "Z", /* ansi */ false);
+        ColumnVector actual = CastStrings.toTimestamp(
+            inputCv, "Z", /* ansi */ false, /* is spark 320 */ false);
         ColumnVector expected = ColumnVector.timestampMicroSecondsFromBoxedLongs(expectedTS.toArray(new Long[0]))) {
       AssertUtils.assertColumnsAreEqual(expected, actual);
     }
 
     // 2. test ansi mode true, has large year and has DST
     try (ColumnVector inputCv = ColumnVector.fromStrings(input.toArray(new String[0]));
-        ColumnVector actual = CastStrings.toTimestamp(inputCv, "Z", /* ansi */ true)) {
+        ColumnVector actual = CastStrings.toTimestamp(
+            inputCv, "Z", /* ansi */ true, /* is spark 320 */ false)) {
       Assertions.assertNull(actual);
     }
 
@@ -962,7 +968,8 @@ public class CastStringsTest {
       expectedTS.add(Long.parseLong(row.get(1).toString()));
     }
     try (ColumnVector inputCv = ColumnVector.fromStrings(input.toArray(new String[0]));
-        ColumnVector actual = CastStrings.toTimestamp(inputCv, "Z", /* ansi */ true);
+        ColumnVector actual = CastStrings.toTimestamp(
+            inputCv, "Z", /* ansi */ true, /* is spark 320 */ false);
         ColumnVector expected = ColumnVector.timestampMicroSecondsFromBoxedLongs(expectedTS.toArray(new Long[0]))) {
       AssertUtils.assertColumnsAreEqual(expected, actual);
     }
@@ -979,7 +986,8 @@ public class CastStringsTest {
     }
     long days = LocalDate.now().toEpochDay();
     try (ColumnVector inputCv = ColumnVector.fromStrings(input.toArray(new String[0]));
-        ColumnVector actual = CastStrings.toTimestamp(inputCv, "Z", /* ansi */false);
+        ColumnVector actual = CastStrings.toTimestamp(
+            inputCv, "Z", /* ansi */false, /* is spark 320 */ false);
         HostColumnVector hcv = actual.copyToHost();) {
       // this test may happen at mid-night, so the date may be different    
       long expectedTs1 = (days * 24 * 3600 + 1) * 1000000L;
@@ -998,7 +1006,8 @@ public class CastStringsTest {
       input.add(row.get(0).toString());
     }
     try (ColumnVector inputCv = ColumnVector.fromStrings(input.toArray(new String[0]));
-        ColumnVector actual = CastStrings.toTimestamp(inputCv, "Z", /* ansi */true)) {
+        ColumnVector actual = CastStrings.toTimestamp(
+            inputCv, "Z", /* ansi */true, /* is spark 320 */ false)) {
       Assertions.assertNull(actual);
     }
 
@@ -1012,7 +1021,8 @@ public class CastStringsTest {
       input.add(row.get(0).toString());
     }
     try (ColumnVector inputCv = ColumnVector.fromStrings(input.toArray(new String[0]));
-        ColumnVector actual = CastStrings.toTimestamp(inputCv, "Z", /* ansi */true)) {
+        ColumnVector actual = CastStrings.toTimestamp(
+            inputCv, "Z", /* ansi */true, /* is spark 320 */ false)) {
       Assertions.assertNull(actual);
     }
   }
@@ -1062,7 +1072,8 @@ public class CastStringsTest {
       }
     }
     try (ColumnVector inputCv = ColumnVector.fromStrings(input.toArray(new String[0]));
-        ColumnVector actual = CastStrings.toTimestamp(inputCv, "Z", /* ansi */ false);
+        ColumnVector actual = CastStrings.toTimestamp(
+            inputCv, "Z", /* ansi */ false, /* is spark 320 */ false);
         ColumnVector expected = ColumnVector.timestampMicroSecondsFromBoxedLongs(
             expectedTS.toArray(new Long[0]))) {
       AssertUtils.assertColumnsAreEqual(expected, actual);
@@ -1070,7 +1081,8 @@ public class CastStringsTest {
 
     // 2. test ansi mode true
     try (ColumnVector inputCv = ColumnVector.fromStrings(input.toArray(new String[0]));
-        ColumnVector actual = CastStrings.toTimestamp(inputCv, "Z", /* ansi */ true)) {
+        ColumnVector actual = CastStrings.toTimestamp(
+            inputCv, "Z", /* ansi */ true, /* is spark 320 */ false)) {
       Assertions.assertNull(actual);
     }
 
@@ -1089,7 +1101,8 @@ public class CastStringsTest {
       expectedTS.add(Long.parseLong(row.get(1).toString()));
     }
     try (ColumnVector inputCv = ColumnVector.fromStrings(input.toArray(new String[0]));
-        ColumnVector actual = CastStrings.toTimestamp(inputCv, "Z", /* ansi */ true);
+        ColumnVector actual = CastStrings.toTimestamp(
+            inputCv, "Z", /* ansi */ true, /* is spark 320 */ false);
         ColumnVector expected = ColumnVector.timestampMicroSecondsFromBoxedLongs(
             expectedTS.toArray(new Long[0]))) {
       AssertUtils.assertColumnsAreEqual(expected, actual);
@@ -1106,7 +1119,8 @@ public class CastStringsTest {
     }
     long days = LocalDate.now().toEpochDay();
     try (ColumnVector inputCv = ColumnVector.fromStrings(input.toArray(new String[0]));
-        ColumnVector actual = CastStrings.toTimestamp(inputCv, "Z", /* ansi */ false);
+        ColumnVector actual = CastStrings.toTimestamp(
+            inputCv, "Z", /* ansi */ false, /* is spark 320 */ false);
         HostColumnVector hcv = actual.copyToHost();) {
       long expectedTs1 = (days * 24 * 3600 + 1) * 1000000L;
       long expectedTs2 = ((days + 1) * 24 * 3600 + 1) * 1000000L;
@@ -1123,7 +1137,8 @@ public class CastStringsTest {
       input.add(row.get(0).toString());
     }
     try (ColumnVector inputCv = ColumnVector.fromStrings(input.toArray(new String[0]));
-        ColumnVector actual = CastStrings.toTimestamp(inputCv, "Z", /* ansi */ true)) {
+        ColumnVector actual = CastStrings.toTimestamp(
+            inputCv, "Z", /* ansi */ true, /* is spark 320 */ false)) {
       Assertions.assertNull(actual);
     }
 
@@ -1136,7 +1151,8 @@ public class CastStringsTest {
       input.add(row.get(0).toString());
     }
     try (ColumnVector inputCv = ColumnVector.fromStrings(input.toArray(new String[0]));
-        ColumnVector actual = CastStrings.toTimestamp(inputCv, "Z", /* ansi */ true)) {
+        ColumnVector actual = CastStrings.toTimestamp(
+            inputCv, "Z", /* ansi */ true, /* is spark 320 */ false)) {
       Assertions.assertNull(actual);
     }
   }
@@ -1214,7 +1230,8 @@ public class CastStringsTest {
         ColumnVector actual = CastStrings.toTimestamp(
             inputCv,
             "America/Los_Angeles", // non-UTC default timezone
-            /* ansi */ false);
+            /* ansi */ false,
+            /* is spark 320 */ false);
         ColumnVector expected = ColumnVector.timestampMicroSecondsFromBoxedLongs(micors1)) {
       AssertUtils.assertColumnsAreEqual(expected, actual);
     }
@@ -1227,7 +1244,8 @@ public class CastStringsTest {
         ColumnVector actual = CastStrings.toTimestamp(
             inputCv,
             "America/Los_Angeles", // non-UTC default timezone
-            /* ansi */ false);
+            /* ansi */ false,
+            /* is spark 320 */ false);
         ColumnVector expected = ColumnVector.timestampMicroSecondsFromBoxedLongs(micors2)) {
       AssertUtils.assertColumnsAreEqual(expected, actual);
     }

--- a/thirdparty/cudf-pins/versions.json
+++ b/thirdparty/cudf-pins/versions.json
@@ -77,7 +77,7 @@
     {
       "always_download" : true,
       "git_shallow" : false,
-      "git_tag" : "ad66c30aaa11603ab2749c49fe7cb8ae69fe70ee",
+      "git_tag" : "a79389c0ad9e6424df11beac507d563018044da4",
       "git_url" : "https://github.com/rapidsai/kvikio.git",
       "version" : "25.06"
     },

--- a/thirdparty/cudf-pins/versions.json
+++ b/thirdparty/cudf-pins/versions.json
@@ -77,7 +77,7 @@
     {
       "always_download" : true,
       "git_shallow" : false,
-      "git_tag" : "a79389c0ad9e6424df11beac507d563018044da4",
+      "git_tag" : "764c0f13f1b088b587737a1c6fa5d788dab6c656",
       "git_url" : "https://github.com/rapidsai/kvikio.git",
       "version" : "25.06"
     },

--- a/thirdparty/cudf-pins/versions.json
+++ b/thirdparty/cudf-pins/versions.json
@@ -77,7 +77,7 @@
     {
       "always_download" : true,
       "git_shallow" : false,
-      "git_tag" : "764c0f13f1b088b587737a1c6fa5d788dab6c656",
+      "git_tag" : "5a123527628945554f00893819171bff2a54c51f",
       "git_url" : "https://github.com/rapidsai/kvikio.git",
       "version" : "25.06"
     },


### PR DESCRIPTION
depends:
* https://github.com/NVIDIA/spark-rapids-jni/pull/3352

Update kernel to match Spark 320

### diffs between spark 320 and spark 321+
### 1. diff getZoneId

Details:


For fixed offset timezone, e.g.: +08:00, Java requires hour, minute and second are 2 digits.
For Spark 320, Below `getZoneId` code replaces 1 digit hour to 2 digits hour: h:xx => 0h:xx
so only supports: [+-]x:xx, [+-]xx:xx fixed timezones, e.g.:
+1:02
+01:02
UT-1:02
UT+01:02
GMT-1:02
GMT+01:02
...

Spark 320:
https://github.com/apache/spark/blob/v3.2.0/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala#L53-L56
```scala
  def getZoneId(timeZoneId: String): ZoneId = {
    // To support the (+|-)h:mm format because it was supported before Spark 3.0.
    ZoneId.of(timeZoneId.replaceFirst("(\\+|\\-)(\\d):", "$10$2:"), ZoneId.SHORT_IDS)
  }
```
Spark 321:
Below Below `getZoneId` code replaces 1 digit hour to 2 digits hour, and 1 digit minute to 2 digits minute: x:x => xx:xx
So supports: [+-]x:x, [+-]x:xx, [+-]xx:x, [+-]xx:xx

https://github.com/apache/spark/blob/v3.2.1/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala#L53-L61
```scala
  def getZoneId(timeZoneId: String): ZoneId = {
    val formattedZoneId = timeZoneId
      // To support the (+|-)h:mm format because it was supported before Spark 3.0.
      .replaceFirst("(\\+|\\-)(\\d):", "$10$2:")
      // To support the (+|-)hh:m format because it was supported before Spark 3.0.
      .replaceFirst("(\\+|\\-)(\\d\\d):(\\d)$", "$1$2:0$3")

    ZoneId.of(formattedZoneId, ZoneId.SHORT_IDS)
  }
```
Note: the second `replaceFirst` can convert "01:2" to "01:02", can not convert "01:2:03" to "01:02:03"
So the "01:2:03" is special case, it's invalid.

#### diff parseTimestampString
https://github.com/apache/spark/blob/v3.2.0/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala#L251

https://github.com/apache/spark/blob/v3.2.1/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala#L256
![diff2](https://github.com/user-attachments/assets/9591e126-4327-4cba-b2bd-4ce7258333b0)

### changes

- Pass is spark 320 boolean to kernel
- Port Spark 320 code and Spark 321 code
- Refactor `parse_tz_from_sign`
- Add test case
